### PR TITLE
fix the sticky events duplication bug

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -53,7 +53,7 @@ jobs:
         steps:
             - name: Check membership
               if: github.event.pull_request.user.login != 'renovate[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'
-              uses: tspascoal/get-user-teams-membership@818140d631d5f29f26b151afbe4179f87d9ceb5e # v4
+              uses: tspascoal/get-user-teams-membership@b2546c5affc730fd8e3d8483ae9ad3621938c2f9 # v4
               id: teams
               with:
                   username: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/release-make.yml
+++ b/.github/workflows/release-make.yml
@@ -73,7 +73,7 @@ jobs:
 
             - name: Get draft release
               id: draft-release
-              uses: cardinalby/git-get-release-action@5172c3a026600b1d459b117738c605fabc9e4e44 # 1.2.5
+              uses: cardinalby/git-get-release-action@2ab178299eecb253f820dcf2cce11f62be1178f7 # 1.2.6
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               with:

--- a/.github/workflows/triage-stale.yml
+++ b/.github/workflows/triage-stale.yml
@@ -12,7 +12,7 @@ jobs:
             issues: write
             pull-requests: write
         steps:
-            - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
+            - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
               with:
                   operations-per-run: 250
                   days-before-issue-stale: -1

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "lint:knip": "knip",
         "test": "vitest run",
         "test:watch": "vitest watch",
+        "test:bug-5205": "vitest run spec/unit/models/room-sticky-events.spec.ts -t \"issue #5205\"",
         "coverage": "pnpm test --coverage"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "eslint-config-prettier": "^10.0.0",
         "eslint-import-resolver-typescript": "^4.0.0",
         "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-jsdoc": "^62.0.0",
+        "eslint-plugin-jsdoc": "^63.0.0",
         "eslint-plugin-matrix-org": "^3.0.0",
         "eslint-plugin-n": "^14.0.0",
         "eslint-plugin-tsdoc": "^0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,8 +353,8 @@ importers:
         specifier: ^2.26.0
         version: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
       eslint-plugin-jsdoc:
-        specifier: ^62.0.0
-        version: 62.9.0(eslint@8.57.1)
+        specifier: ^63.0.0
+        version: 63.0.0(eslint@8.57.1)
       eslint-plugin-matrix-org:
         specifier: ^3.0.0
         version: 3.0.0(7aefc8337d6e3c7c13929bacdbb1e455)
@@ -2399,9 +2399,9 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-jsdoc@62.9.0:
-    resolution: {integrity: sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+  eslint-plugin-jsdoc@63.0.0:
+    resolution: {integrity: sha512-eDHuVGyZydr4BKgjXouU7bsn5qaqUlObXBSWRJk3vXcQgXVFnrwWIqpP7uBhRX9NQpk6NIIFyRc6F6omZNi/8g==}
+    engines: {node: ^22.13.0 || >=24}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
@@ -6293,7 +6293,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsdoc@62.9.0(eslint@8.57.1):
+  eslint-plugin-jsdoc@63.0.0(eslint@8.57.1):
     dependencies:
       '@es-joy/jsdoccomment': 0.86.0
       '@es-joy/resolve.exports': 1.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
-nodeLinker: hoisted
-
 peerDependencyRules:
     allowedVersions:
         eslint: "8"

--- a/spec/test-utils/client.ts
+++ b/spec/test-utils/client.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { type MockedObject } from "vitest";
+import { type Mock, type MockedObject } from "vitest";
 
 import { type ClientEventHandlerMap, type EmittedEvents, type MatrixClient } from "../../src/client";
 import { TypedEventEmitter } from "../../src/models/typed-event-emitter";
@@ -65,14 +65,14 @@ export const getMockClientWithEventEmitter = (
  * ```
  */
 export const mockClientMethodsUser = (userId = "@alice:domain") => ({
-    getUserId: vi.fn().mockReturnValue(userId),
-    getSafeUserId: vi.fn().mockReturnValue(userId),
-    getUser: vi.fn().mockReturnValue(new User(userId)),
-    isGuest: vi.fn().mockReturnValue(false),
-    mxcUrlToHttp: vi.fn().mockReturnValue("mock-mxcUrlToHttp"),
+    getUserId: vi.fn().mockReturnValue(userId) as Mock,
+    getSafeUserId: vi.fn().mockReturnValue(userId) as Mock,
+    getUser: vi.fn().mockReturnValue(new User(userId)) as Mock,
+    isGuest: vi.fn().mockReturnValue(false) as Mock,
+    mxcUrlToHttp: vi.fn().mockReturnValue("mock-mxcUrlToHttp") as Mock,
     credentials: { userId },
-    getThreePids: vi.fn().mockResolvedValue({ threepids: [] }),
-    getAccessToken: vi.fn(),
+    getThreePids: vi.fn().mockResolvedValue({ threepids: [] }) as Mock,
+    getAccessToken: vi.fn() as Mock,
 });
 
 /**
@@ -84,8 +84,8 @@ export const mockClientMethodsUser = (userId = "@alice:domain") => ({
  * ```
  */
 export const mockClientMethodsEvents = () => ({
-    decryptEventIfNeeded: vi.fn(),
-    getPushActionsForEvent: vi.fn(),
+    decryptEventIfNeeded: vi.fn() as Mock,
+    getPushActionsForEvent: vi.fn() as Mock,
 });
 
 /**

--- a/spec/test-utils/webrtc.ts
+++ b/spec/test-utils/webrtc.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { type Mock } from "vitest";
+
 import {
     type ClientEvent,
     type ClientEventHandlerMap,
@@ -461,8 +463,8 @@ export class MockCallMatrixClient extends TypedEventEmitter<EmittedEvents, Emitt
     public getSyncState = vi.fn<MatrixClient["getSyncState"]>().mockReturnValue(SyncState.Syncing);
 
     public getRooms = vi.fn<MatrixClient["getRooms"]>().mockReturnValue([]);
-    public getRoom = vi.fn();
-    public getFoci = vi.fn();
+    public getRoom: Mock = vi.fn();
+    public getFoci: Mock = vi.fn();
 
     public supportsThreads(): boolean {
         return true;

--- a/spec/unit/models/room-sticky-events.spec.ts
+++ b/spec/unit/models/room-sticky-events.spec.ts
@@ -421,4 +421,73 @@ describe("RoomStickyEvents", () => {
             expect(emitSpy).toHaveBeenCalledWith([], [{ current: ev, previous: newerEv }], []);
         });
     });
+
+    /**
+     * https://github.com/matrix-org/matrix-js-sdk/issues/5205
+     *
+     * Regression guard for the *bug*, not the fix: passes while duplicate stickies exist,
+     * fails once duplicate sticky memberships are prevented.
+     */
+    describe("issue #5205", () => {
+        const rtcStickyBase = {
+            room_id: "!room:example.org",
+            type: "m.rtc.member",
+            msc4354_sticky: { duration_ms: 15000 },
+            sender: "@bob:example.org",
+            origin_server_ts: Date.now(),
+            unsigned: {},
+        };
+
+        it("proves duplicate unkeyed + keyed RTC membership stickies exist (bug #5205)", () => {
+            const unkeyedPreDecrypt = new MatrixEvent({
+                ...rtcStickyBase,
+                event_id: "$unkeyed:example.org",
+                type: "m.room.encrypted",
+                content: {},
+            });
+            const keyedAfterDecrypt = new MatrixEvent({
+                ...rtcStickyBase,
+                event_id: "$keyed:example.org",
+                content: { msc4354_sticky_key: "member-uuid-1" },
+            });
+
+            stickyEvents.addStickyEvents([unkeyedPreDecrypt]);
+            stickyEvents.addStickyEvents([keyedAfterDecrypt]);
+
+            const active = [...stickyEvents.getStickyEvents()];
+            const unkeyed = stickyEvents.getUnkeyedStickyEvent(rtcStickyBase.sender, "m.room.encrypted");
+            const keyed = stickyEvents.getKeyedStickyEvent(rtcStickyBase.sender, rtcStickyBase.type, "member-uuid-1");
+
+            expect(active).toHaveLength(2);
+            expect(unkeyed).toHaveLength(1);
+            expect(keyed).toBe(keyedAfterDecrypt);
+            expect(active).toContain(unkeyedPreDecrypt);
+            expect(active).toContain(keyedAfterDecrypt);
+        });
+
+        it("proves duplicate for Matrix 2.0 org.matrix.msc4143.rtc.member (bug #5205)", () => {
+            const msc4143Type = "org.matrix.msc4143.rtc.member";
+            const unkeyedPreDecrypt = new MatrixEvent({
+                ...rtcStickyBase,
+                event_id: "$unkeyed-m2:example.org",
+                type: "m.room.encrypted",
+                content: {},
+            });
+            const keyedAfterDecrypt = new MatrixEvent({
+                ...rtcStickyBase,
+                event_id: "$keyed-m2:example.org",
+                type: msc4143Type,
+                content: { msc4354_sticky_key: "member-uuid-1" },
+            });
+
+            stickyEvents.addStickyEvents([unkeyedPreDecrypt]);
+            stickyEvents.addStickyEvents([keyedAfterDecrypt]);
+
+            expect([...stickyEvents.getStickyEvents()]).toHaveLength(2);
+            expect(stickyEvents.getKeyedStickyEvent(rtcStickyBase.sender, msc4143Type, "member-uuid-1")).toBe(
+                keyedAfterDecrypt,
+            );
+            expect(stickyEvents.getUnkeyedStickyEvent(rtcStickyBase.sender, "m.room.encrypted")).toHaveLength(1);
+        });
+    });
 });

--- a/spec/unit/models/room-sticky-events.spec.ts
+++ b/spec/unit/models/room-sticky-events.spec.ts
@@ -2,6 +2,7 @@ import { type Mock } from "vitest";
 
 import { type IStickyEvent, MatrixEvent } from "../../../src";
 import { RoomStickyEventsStore, RoomStickyEventsEvent } from "../../../src/models/room-sticky-events";
+import { EventType } from "../../../src/@types/event";
 
 describe("RoomStickyEvents", () => {
     let stickyEvents: RoomStickyEventsStore;
@@ -116,6 +117,18 @@ describe("RoomStickyEvents", () => {
             expect([...stickyEvents.getStickyEvents()]).toEqual([ev]);
             expect(emitSpy).toHaveBeenCalledWith([ev], [], []);
         });
+
+        it("should not add an unkeyed event whose type is m.room.encrypted", () => {
+            stickyEvents.addStickyEvents([
+                new MatrixEvent({
+                    ...stickyEvent,
+                    type: EventType.RoomMessageEncrypted,
+                    content: {},
+                }),
+            ]);
+            expect([...stickyEvents.getStickyEvents()]).toHaveLength(0);
+        });
+
         it("should emit when a new unkeyed sticky event is added", () => {
             stickyEvents.on(RoomStickyEventsEvent.Update, emitSpy);
             const ev = new MatrixEvent({

--- a/spec/unit/models/room.spec.ts
+++ b/spec/unit/models/room.spec.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { type MockedObject } from "vitest";
 
 import { Direction, EventType, type MatrixClient, MatrixEvent, Room } from "../../../src";
+import { RoomStickyEventsEvent } from "../../../src/models/room-sticky-events";
 
 const CREATOR_USER_ID = "@creator:example.org";
 const MODERATOR_USER_ID = "@moderator:example.org";
@@ -235,6 +236,75 @@ describe("Room", () => {
             room.recalculate();
 
             expect(room.getAltAliases()).toEqual(["#foo:bar"]);
+        });
+    });
+
+    describe("_unstable_addStickyEvents", () => {
+        function createMockClientWithCrypto(): MockedObject<MatrixClient> {
+            return {
+                supportsThreads: vi.fn().mockReturnValue(true),
+                decryptEventIfNeeded: vi.fn().mockResolvedValue(undefined),
+                getUserId: vi.fn().mockReturnValue(CREATOR_USER_ID),
+                getCrypto: vi.fn().mockReturnValue({}),
+            } as unknown as MockedObject<MatrixClient>;
+        }
+
+        it("should call decryptEventIfNeeded for an encrypted sticky event, then add it to the store", async () => {
+            const mockClient = createMockClientWithCrypto();
+            const room = new Room("!room:example.org", mockClient, CREATOR_USER_ID);
+
+            const encryptedStickyEvent = new MatrixEvent({
+                type: EventType.RoomMessageEncrypted,
+                event_id: "$encrypted-sticky",
+                room_id: room.roomId,
+                sender: CREATOR_USER_ID,
+                origin_server_ts: Date.now(),
+                msc4354_sticky: { duration_ms: 15000 },
+                content: {},
+            });
+
+            mockClient.decryptEventIfNeeded.mockImplementation(async (event) => {
+                // `clearEvent` is a private field on MatrixEvent; casting to any is the only way
+                // to inject a decrypted payload without going through the full crypto stack.
+                (event as any).clearEvent = {
+                    type: "org.example.message",
+                    content: { msc4354_sticky_key: "my-key" },
+                };
+            });
+
+            const emitSpy = vi.fn();
+            room.on(RoomStickyEventsEvent.Update, emitSpy);
+
+            await room._unstable_addStickyEvents([encryptedStickyEvent]);
+
+            expect(mockClient.decryptEventIfNeeded).toHaveBeenCalledWith(encryptedStickyEvent);
+            expect([...room._unstable_getStickyEvents()]).toContain(encryptedStickyEvent);
+            expect(emitSpy).toHaveBeenCalled();
+        });
+
+        it("should skip an encrypted sticky event when crypto is unavailable", async () => {
+            const mockClient = {
+                supportsThreads: vi.fn().mockReturnValue(true),
+                decryptEventIfNeeded: vi.fn().mockResolvedValue(undefined),
+                getUserId: vi.fn().mockReturnValue(CREATOR_USER_ID),
+                getCrypto: vi.fn().mockReturnValue(null),
+            } as unknown as MockedObject<MatrixClient>;
+            const room = new Room("!room:example.org", mockClient, CREATOR_USER_ID);
+
+            const encryptedStickyEvent = new MatrixEvent({
+                type: EventType.RoomMessageEncrypted,
+                event_id: "$encrypted-sticky-no-crypto",
+                room_id: room.roomId,
+                sender: CREATOR_USER_ID,
+                origin_server_ts: Date.now(),
+                msc4354_sticky: { duration_ms: 15000 },
+                content: {},
+            });
+
+            await room._unstable_addStickyEvents([encryptedStickyEvent]);
+
+            expect(mockClient.decryptEventIfNeeded).not.toHaveBeenCalled();
+            expect([...room._unstable_getStickyEvents()]).toHaveLength(0);
         });
     });
 

--- a/src/embedded.ts
+++ b/src/embedded.ts
@@ -758,7 +758,7 @@ export class RoomWidgetClient extends MatrixClient {
             }
 
             this.emit(ClientEvent.Event, event);
-            if (event.unstableStickyInfo !== undefined) this.room!._unstable_addStickyEvents([event]);
+            if (event.unstableStickyInfo !== undefined) await this.room!._unstable_addStickyEvents([event]);
             this.setSyncState(SyncState.Syncing);
             logger.info(`Received event ${event.getId()} ${event.getType()}`);
         } else {

--- a/src/models/room-sticky-events.ts
+++ b/src/models/room-sticky-events.ts
@@ -1,4 +1,5 @@
 import { logger as loggerInstance } from "../logger.ts";
+import { EventType } from "../@types/event.ts";
 import { type MatrixEvent } from "./event.ts";
 import { TypedEventEmitter } from "./typed-event-emitter.ts";
 
@@ -156,6 +157,8 @@ export class RoomStickyEventsStore extends TypedEventEmitter<RoomStickyEventsEve
         const stickyEvent = event as StickyMatrixEvent;
 
         if (stickyKey === undefined) {
+            if (event.isEncrypted() || type === EventType.RoomMessageEncrypted) return { added: false };
+
             this.unkeyedStickyEvents.add(stickyEvent);
             // Recalculate the next expiry time.
             this.nextStickyEventExpiryTs = Math.min(event.unstableStickyExpiresAt, this.nextStickyEventExpiryTs);

--- a/src/models/room-sticky-events.ts
+++ b/src/models/room-sticky-events.ts
@@ -156,6 +156,12 @@ export class RoomStickyEventsStore extends TypedEventEmitter<RoomStickyEventsEve
         const stickyEvent = event as StickyMatrixEvent;
 
         if (stickyKey === undefined) {
+            // Encrypted stickies have no readable msc4354_sticky_key yet. They will be re-added
+            // after decryption via Room._unstable_addStickyEvents. Storing them now would create a
+            // duplicate unkeyed entry alongside the later keyed one.
+            // See https://github.com/matrix-org/matrix-js-sdk/issues/5205
+            if (event.isEncrypted() || type === "m.room.encrypted") return { added: false };
+
             this.unkeyedStickyEvents.add(stickyEvent);
             // Recalculate the next expiry time.
             this.nextStickyEventExpiryTs = Math.min(event.unstableStickyExpiresAt, this.nextStickyEventExpiryTs);

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -3471,12 +3471,65 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
     /**
      * Add a series of sticky events, emitting `RoomEvent.StickyEvents` if any
      * changes were made.
+     *
+     * Encrypted sticky events are decrypted before being passed to the store so that
+     * their `msc4354_sticky_key` is available. This prevents a duplicate unkeyed entry
+     * being created alongside the keyed one that arrives after decryption.
+     * See https://github.com/matrix-org/matrix-js-sdk/issues/5205
+     *
      * @param events A set of new sticky events.
      * @internal
      */
     // eslint-disable-next-line
-    public _unstable_addStickyEvents(events: MatrixEvent[]): ReturnType<RoomStickyEventsStore["addStickyEvents"]> {
-        return this.stickyEvents.addStickyEvents(events);
+    public async _unstable_addStickyEvents(
+        events: MatrixEvent[],
+    ): Promise<ReturnType<RoomStickyEventsStore["addStickyEvents"]>> {
+        const results = await Promise.allSettled(events.map((event) => this.decryptStickyEvent(event)));
+        const decrypted = results.flatMap((r) => (r.status === "fulfilled" && r.value !== null ? [r.value] : []));
+        return this.stickyEvents.addStickyEvents(decrypted);
+    }
+
+    /**
+     * Resolves a sticky event to its decrypted form before it is inserted into the store.
+     *
+     * Returns `null` for events that should not be stored: those with missing sticky metadata,
+     * or encrypted events that still lack a `msc4354_sticky_key` after a decryption attempt.
+     * Never throws — decrypt failures are logged and treated as skipped events so that a single
+     * undecryptable sticky cannot abort the surrounding sync processing.
+     */
+    private async decryptStickyEvent(event: MatrixEvent): Promise<MatrixEvent | null> {
+        if (event.unstableStickyInfo === undefined) return null;
+
+        // Already has a key — nothing to do.
+        if (typeof event.getContent().msc4354_sticky_key === "string") return event;
+
+        // Plain (non-encrypted) unkeyed sticky — allowed through as-is.
+        if (!event.isEncrypted() && !event.shouldAttemptDecryption()) return event;
+
+        if (!this.client.getCrypto()) {
+            logger.debug(`Skipping encrypted sticky event ${event.getId()}: crypto not available`);
+            return null;
+        }
+
+        try {
+            await this.client.decryptEventIfNeeded(event);
+            if (event.isBeingDecrypted()) await event.getDecryptionPromise();
+        } catch (e) {
+            logger.warn(`Failed to decrypt sticky event ${event.getId()}, skipping`, e);
+            return null;
+        }
+
+        if (typeof event.getContent().msc4354_sticky_key === "string") {
+            return event;
+        }
+
+        // Still encrypted after decrypt attempt — drop it; the store would reject it anyway.
+        if (event.isEncrypted()) {
+            logger.debug(`Skipping sticky event ${event.getId()}: still encrypted after decryption attempt`);
+            return null;
+        }
+
+        return event;
     }
 
     /**

--- a/src/models/room.ts
+++ b/src/models/room.ts
@@ -3475,8 +3475,48 @@ export class Room extends ReadReceipt<RoomEmittedEvents, RoomEventHandlerMap> {
      * @internal
      */
     // eslint-disable-next-line
-    public _unstable_addStickyEvents(events: MatrixEvent[]): ReturnType<RoomStickyEventsStore["addStickyEvents"]> {
-        return this.stickyEvents.addStickyEvents(events);
+    public async _unstable_addStickyEvents(
+        events: MatrixEvent[],
+    ): Promise<ReturnType<RoomStickyEventsStore["addStickyEvents"]>> {
+        const results = await Promise.allSettled(events.map((event) => this.decryptStickyEvent(event)));
+        const decrypted = results.flatMap((r) => (r.status === "fulfilled" && r.value !== null ? [r.value] : []));
+        return this.stickyEvents.addStickyEvents(decrypted);
+    }
+
+    /**
+     * Resolves a sticky event to its decrypted form before it is inserted into the store.
+     *
+     * Returns `null` for events that should not be stored: those with missing sticky metadata,
+     * or encrypted events that still lack a `msc4354_sticky_key` after a decryption attempt.
+     * Encryption failures are logged and treated as skipped events so that a single
+     * undecryptable sticky cannot abort the surrounding sync processing.
+     */
+    private async decryptStickyEvent(event: MatrixEvent): Promise<MatrixEvent | null> {
+        if (event.unstableStickyInfo === undefined) return null;
+
+        if (typeof event.getContent().msc4354_sticky_key === "string" || !event.isEncrypted()) return event;
+
+        if (!this.client.getCrypto()) {
+            logger.debug(`Skipping encrypted sticky event ${event.getId()}: crypto not available`);
+            return null;
+        }
+
+        try {
+            await this.client.decryptEventIfNeeded(event);
+            if (event.isBeingDecrypted()) await event.getDecryptionPromise();
+        } catch (e) {
+            logger.warn(`Failed to decrypt sticky event ${event.getId()}, skipping`, e);
+            return null;
+        }
+
+        if (typeof event.getContent().msc4354_sticky_key === "string") return event;
+
+        if (event.isEncrypted()) {
+            logger.debug(`Skipping sticky event ${event.getId()}: still encrypted after decryption attempt`);
+            return null;
+        }
+
+        return event;
     }
 
     /**

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1466,7 +1466,7 @@ export class SyncApi {
                 );
                 // Note: We calculate sticky events before emitting `.Room` as it's nice to have
                 // sticky events calculated and ready to go.
-                room._unstable_addStickyEvents(stickyEventsAndStickyEventsFromTheTimeline);
+                await room._unstable_addStickyEvents(stickyEventsAndStickyEventsFromTheTimeline);
 
                 room.recalculate();
                 if (joinObj.isBrandNewRoom) {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Changes

- `_unstable_addStickyEvents` in room.ts is now `async` and runs each sticky through `decryptStickyEvent` before calling the store, so encrypted stickies are decrypted (and get their `msc4354_sticky_key`) before insertion. `RoomStickyEventsStore` rejects unkeyed m.room.encrypted events so ciphertext cannot sit in `unkeyedStickyEvents`. sync.ts and embedded.ts now await that async add path.
- Tests were added in room-sticky-events.spec.ts and room.spec.ts for the store guard and the decrypt-then-add flow.

## Cause
Encrypted sticky events arrive as `m.room.encrypted` with no `msc4354_sticky_key` in the ciphertext, so the SDK treated them as unkeyed stickies and stored them immediately. After decryption, the same logical event was added again (now with a sticky key or as a plain event), so the sticky store held two entries for one sticky.

## Fix
`_unstable_addStickyEvents` now decrypts sticky events first via `decryptStickyEvent`, and only passes through events that are already keyed, plain unkeyed stickies, or successfully decrypted. As a backstop, `RoomStickyEventsStore` refuses to add unkeyed `m.room.encrypted` events, and sync/widget paths `await` the async add so decryption finishes before the store is updated.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
